### PR TITLE
Add sample react extension for public app project

### DIFF
--- a/public-app-getting-started-template/README.md
+++ b/public-app-getting-started-template/README.md
@@ -8,6 +8,14 @@ TBD
 
 ## Set up
 Once you run `hs project upload` and the projects gets fully built and deployed onto your developer portal. You want to then install the app to a portal of your choice via the install URL located in your App's auth tab.
+![image](https://github.com/kemmerle/hubspot-public-app-template/assets/44659712/b1d89c75-9055-4828-9e74-73e75cb29056)
 
 
 Once the app is installed onto that portal, you want to be a super-admin and navigate to the related object's record customization page. i.e. Go to your portal settings, scroll down to Data Management then expand the Objects nav item to the appropriate object and click `Record Customization` and click the specified layout.
+![image](https://github.com/kemmerle/hubspot-public-app-template/assets/44659712/740b86f6-ee49-4667-98fc-35b2e4ee9005)
+
+Either update the default view or create a team view and add the UI extension card to the view. 
+![image](https://github.com/kemmerle/hubspot-public-app-template/assets/44659712/d8e74c43-f6d5-4f4e-8f52-f5324f55c565)
+
+## Gotchas
+Public app UI extensions currently only render for enterprise portals (non enterprise portals are a work in progress)

--- a/public-app-getting-started-template/README.md
+++ b/public-app-getting-started-template/README.md
@@ -9,7 +9,7 @@ TBD
 ## Set up
 NOTE: You need to be a super-admin in the developer account, where you will be uploading your app.
 
-1. Run hs project upload --account=<dev-acct-id> to build and deploy the project to your developer account.
+1. Run `hs project upload --account=<dev-acct-id>` to build and deploy the project to your developer account.
 2. Retrieve the install URL located in your app's auth tab.
 3. Use that install URL to install the app in a developer test account of your choice.
 ![image](https://github.com/kemmerle/hubspot-public-app-template/assets/44659712/b1d89c75-9055-4828-9e74-73e75cb29056)

--- a/public-app-getting-started-template/README.md
+++ b/public-app-getting-started-template/README.md
@@ -7,14 +7,20 @@ This is a project containing a public app, so developers can get up and running 
 TBD
 
 ## Set up
-Once you run `hs project upload` and the projects gets fully built and deployed onto your developer portal. You want to then install the app to a portal of your choice via the install URL located in your App's auth tab.
+NOTE: You need to be a super-admin in the developer account, where you will be uploading your app.
+
+1. Run hs project upload --account=<dev-acct-id> to build and deploy the project to your developer account.
+2. Retrieve the install URL located in your app's auth tab.
+3. Use that install URL to install the app in a developer test account of your choice.
 ![image](https://github.com/kemmerle/hubspot-public-app-template/assets/44659712/b1d89c75-9055-4828-9e74-73e75cb29056)
 
 
-Once the app is installed onto that portal, you want to be a super-admin and navigate to the related object's record customization page. i.e. Go to your portal settings, scroll down to Data Management then expand the Objects nav item to the appropriate object and click `Record Customization` and click the specified layout.
+4. Once the app is installed in the developer test portal, navigate to the related object's record customization page. For example, if your UIE extension card will appear on Contacts record pages, navigate to the Contacts record customization page.
+5. Scroll down to Data Management, expand the Objects navigation item, and select the appropriate object.
+6. Select the Record Customization tab, and choose the specified layout.
 ![image](https://github.com/kemmerle/hubspot-public-app-template/assets/44659712/740b86f6-ee49-4667-98fc-35b2e4ee9005)
 
-Either update the default view or create a team view and add the UI extension card to the view. 
+7. You can either update the default view or create a team view. Then add the UI Extension card to it.
 ![image](https://github.com/kemmerle/hubspot-public-app-template/assets/44659712/d8e74c43-f6d5-4f4e-8f52-f5324f55c565)
 
 ## Gotchas

--- a/public-app-getting-started-template/README.md
+++ b/public-app-getting-started-template/README.md
@@ -5,3 +5,9 @@ This is a project containing a public app, so developers can get up and running 
 ## Requirements
 
 TBD
+
+## Set up
+Once you run `hs project upload` and the projects gets fully built and deployed onto your developer portal. You want to then install the app to a portal of your choice via the install URL located in your App's auth tab.
+
+
+Once the app is installed onto that portal, you want to be a super-admin and navigate to the related object's record customization page. i.e. Go to your portal settings, scroll down to Data Management then expand the Objects nav item to the appropriate object and click `Record Customization` and click the specified layout.

--- a/public-app-getting-started-template/src/app/extensions/Example.tsx
+++ b/public-app-getting-started-template/src/app/extensions/Example.tsx
@@ -1,0 +1,12 @@
+
+import React from 'react';
+import { Text } from '@hubspot/ui-extensions';
+import { hubspot } from '@hubspot/ui-extensions';
+
+hubspot.extend(({context}) => (<Hello context={context}/>));
+
+const Hello = ({ context }) => {
+  return (
+    <Text>Hello world</Text>
+  );
+};

--- a/public-app-getting-started-template/src/app/extensions/card.json
+++ b/public-app-getting-started-template/src/app/extensions/card.json
@@ -1,0 +1,16 @@
+{
+  "type": "crm-card",
+  "data": {
+    "title": "Hello World",
+    "uid": "hello-world-card",
+    "location": "crm.record.tab",
+    "module": {
+      "file": "Example.tsx"
+    },
+    "objectTypes": [
+      {
+        "name": "contacts"
+      }
+    ]
+  }
+}

--- a/public-app-getting-started-template/src/app/extensions/package.json
+++ b/public-app-getting-started-template/src/app/extensions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hubspot-example-extension",
+  "version": "0.1.0",
+  "license": "MIT",
+  "dependencies": {
+    "@hubspot/ui-extensions": "latest",
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/public-app-getting-started-template/src/app/public-app.json
+++ b/public-app-getting-started-template/src/app/public-app.json
@@ -21,5 +21,14 @@
     "documentationUrl": "https://example.com/docs",
     "supportUrl": "https://example.com/support",
     "supportPhone": "1-800-555-5555"
+  },
+  "extensions": {
+    "crm": {
+      "cards": [
+        {
+          "file": "./extensions/card.json"
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
This should be able to be built via `hs project upload` on a developer portal given the proper gates are ungated. 